### PR TITLE
Update general.aliases.bash

### DIFF
--- a/aliases/available/general.aliases.bash
+++ b/aliases/available/general.aliases.bash
@@ -37,7 +37,6 @@ then
 fi
 
 alias c='clear'
-alias k='clear'
 alias cls='clear'
 
 alias edit="$EDITOR"


### PR DESCRIPTION
Remove `k` as an alias for clear -- this conflicts with the k tool for kubernetes. 